### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/gulpPluginFabric.js
+++ b/gulpPluginFabric.js
@@ -5,8 +5,7 @@
 
 const
   through = require('through2'),
-  gutil = require('gulp-util'),
-  PluginError = gutil.PluginError;
+  PluginError = require('plugin-error');
 
 /**
  * Fabric that creates a gulp plug-in for a specified Converter class.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/roman-spiridonov/gulp-plugin-fabric#readme",
   "dependencies": {
-    "gulp-util": "^3.0.8",
+    "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Following the advice at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5 this replaces the deprecated `gulp-util`, from which we only needed `PluginError`, with the dedicated `plugin-error` package.